### PR TITLE
Find conda-requirements.txt and requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 Conda Buildpack
 ===============
 
-This is a fork of Heroku build pack for conda (https://github.com/kennethreitz/conda-buildpack) that supports Python 3. It should be used in multi-buildpack setup together with Heroku's official build pack (see
-https://github.com/ddollar/heroku-buildpack-multi).
-
-
 This buildpack enables the installation of binary packages through the
 open source [conda](http://conda.pydata.org/) application.  Conda is
 recognized as being core to Continuum's Anaconda Scientific Python distro

--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -25,5 +25,5 @@ fi
 
 if [ -f requirements.txt ]; then
     puts-step "Installing dependencies using Pip"
-    pip install -r requirements.txt  --exists-action=w --allow-all-external | indent
+    pip install -r requirements.txt  --exists-action=w | indent
 fi

--- a/bin/steps/conda_compile
+++ b/bin/steps/conda_compile
@@ -17,3 +17,13 @@ if [ -f install_dependencies.sh ]; then
   puts-step "Installing dependencies using Conda"
   source install_dependencies.sh
 fi
+
+if [ -f conda-requirements.txt ]; then
+    puts-step "Installing dependencies using Conda"
+    conda install --file conda-requirements.txt --yes | indent
+fi
+
+if [ -f requirements.txt ]; then
+    puts-step "Installing dependencies using Pip"
+    pip install -r requirements.txt  --exists-action=w --allow-all-external | indent
+fi


### PR DESCRIPTION
Your buildpack doesn't read the conda-requirements.txt and requirements.txt (for pip). Now, at least for me, this is the only build pack I need to get my science python 3 flask applications working on heroku.
