### PR TITLE
Upgrade to python 3.6

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -87,7 +87,7 @@ done
 
 # Set context environment variables.
 set-env PATH '$HOME/.heroku/miniconda/bin:$PATH'
-set-default-env PYTHONPATH '/app/.heroku/miniconda/lib/python3.5/site-packages:$PYTHONPATH'
+set-default-env PYTHONPATH '/app/.heroku/miniconda/lib/python3.6/site-packages:$PYTHONPATH'
 set-env PYTHONUNBUFFERED true
 set-default-env LANG en_US.UTF-8
 set-default-env PYTHONHASHSEED random


### PR DESCRIPTION
@abezzub-upstart can you review?

This updates our buildpack to set the `PYTHONPATH` variable to the python 3.6 path.  I plan to merge this at the same time as https://github.com/teamupstart/john_dee/pull/135.